### PR TITLE
Add remaining interface methods

### DIFF
--- a/contracts/HMToken.sol
+++ b/contracts/HMToken.sol
@@ -14,11 +14,6 @@ contract HMToken is HMTokenInterface {
     uint256 private constant BULK_MAX_VALUE = 1000000000 * (10 ** 18);
     uint32  private constant BULK_MAX_COUNT = 100;
 
-    event BulkTransfer(uint256 indexed _txId, uint256 _bulkCount);
-    event BulkTransferFailure(uint256 indexed _txId, uint256 _bulkCount);
-    event BulkApproval(uint256 indexed _txId, uint256 _bulkCount);
-    event BulkApprovalFailure(uint256 indexed _txId, uint256 _bulkCount);
-
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
 

--- a/contracts/HMToken.sol
+++ b/contracts/HMToken.sol
@@ -40,14 +40,14 @@ contract HMToken is HMTokenInterface {
         require(_tos.length < BULK_MAX_COUNT, "Too many recipients");
 
         uint256 _bulkValue = 0;
-        for (uint j = 0; j < _tos.length; ++j) {
+        for (uint256 j = 0; j < _tos.length; ++j) {
             _bulkValue = _bulkValue.add(_values[j]);
         }
         require(_bulkValue < BULK_MAX_VALUE, "Bulk value too high");
 
         _bulkCount = 0;
         bool _success;
-        for (uint i = 0; i < _tos.length; ++i) {
+        for (uint256 i = 0; i < _tos.length; ++i) {
             _success = transferQuiet(_tos[i], _values[i]);
             if (_success) {
                 _bulkCount = _bulkCount.add(1);
@@ -88,14 +88,14 @@ contract HMToken is HMTokenInterface {
         require(_spenders.length < BULK_MAX_COUNT, "Too many spenders");
 
         uint256 _bulkValue = 0;
-        for (uint j = 0; j < _spenders.length; ++j) {
+        for (uint256 j = 0; j < _spenders.length; ++j) {
             _bulkValue = _bulkValue.add(_values[j]);
         }
         require(_bulkValue < BULK_MAX_VALUE, "Bulk value too high");
 
         _bulkCount = 0;
         bool _success;
-        for (uint i = 0; i < _spenders.length; ++i) {
+        for (uint256 i = 0; i < _spenders.length; ++i) {
             _success = increaseApproval(_spenders[i], _values[i]);
             if (_success) {
                 _bulkCount = _bulkCount.add(1);
@@ -107,10 +107,10 @@ contract HMToken is HMTokenInterface {
         return _bulkCount;
     }
 
-    function increaseApproval(address _spender, uint _delta) public returns (bool success) {
+    function increaseApproval(address _spender, uint256 _delta) public returns (bool success) {
         require(_spender != address(0), "Token spender is an uninitialized address");
 
-        uint _oldValue = allowed[msg.sender][_spender];
+        uint256 _oldValue = allowed[msg.sender][_spender];
         if (_oldValue.add(_delta) < _oldValue || _oldValue.add(_delta) >= MAX_UINT256) { // Truncate upon overflow.
             allowed[msg.sender][_spender] = MAX_UINT256.sub(1);
         } else {
@@ -120,10 +120,10 @@ contract HMToken is HMTokenInterface {
         return true;
     }
 
-    function decreaseApproval(address _spender, uint _delta) public returns (bool success) {
+    function decreaseApproval(address _spender, uint256 _delta) public returns (bool success) {
         require(_spender != address(0), "Token spender is an uninitialized address");
 
-        uint _oldValue = allowed[msg.sender][_spender];
+        uint256 _oldValue = allowed[msg.sender][_spender];
         if (_delta > _oldValue) { // Truncate upon overflow.
             allowed[msg.sender][_spender] = 0;
         } else {

--- a/contracts/HMTokenInterface.sol
+++ b/contracts/HMTokenInterface.sol
@@ -18,6 +18,10 @@ contract HMTokenInterface {
 
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+    event BulkTransfer(uint256 indexed _txId, uint256 _bulkCount);
+    event BulkTransferFailure(uint256 indexed _txId, uint256 _bulkCount);
+    event BulkApproval(uint256 indexed _txId, uint256 _bulkCount);
+    event BulkApprovalFailure(uint256 indexed _txId, uint256 _bulkCount);
 
     /// @param _owner The address from which the balance will be retrieved
     /// @return The balance

--- a/contracts/HMTokenInterface.sol
+++ b/contracts/HMTokenInterface.sol
@@ -23,15 +23,17 @@ contract HMTokenInterface {
     event BulkApproval(uint256 indexed _txId, uint256 _bulkCount);
     event BulkApprovalFailure(uint256 indexed _txId, uint256 _bulkCount);
 
-    /// @param _owner The address from which the balance will be retrieved
-    /// @return The balance
-    function balanceOf(address _owner) public view returns (uint256 balance);
-
     /// @notice send `_value` token to `_to` from `msg.sender`
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return Whether the transfer was successful or not
     function transfer(address _to, uint256 _value) public returns (bool success);
+
+    /// @notice send `_values` tokens to `_tos` from `msg.sender`
+    /// @param _tos The addresses of the recipients
+    /// @param _values The amount of tokens to be transferred
+    /// @return Number of transfers completed
+    function transferBulk(address[] memory _tos, uint256[] memory _values, uint256 _txId) public returns (uint256 _bulkCount);
 
     /// @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
     /// @param _from The address of the sender
@@ -46,8 +48,30 @@ contract HMTokenInterface {
     /// @return Whether the approval was successful or not
     function approve(address _spender, uint256 _value) public returns (bool success);
 
+    /// @notice `msg.sender` approves `_spenders` to spend `_values` tokens
+    /// @param _spenders The addresses of the accounts able to transfer the tokens
+    /// @param _values The amount of tokens to be approved for transfers
+    /// @return Number of approvals completed
+    function approveBulk(address[] memory _spenders, uint256[] memory _values, uint256 _txId) public returns (uint256 _bulkCount);
+
+    /// @notice `msg.sender` increases `_spender` to spend `_delta` more tokens
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @param _delta The amount of tokens more to be approved for transfer
+    /// @return Whether the approval increase was successful or not
+    function increaseApproval(address _spender, uint256 _delta) public returns (bool success);
+
+    /// @notice `msg.sender` decreases `_spender` to spend `_delta` less tokens
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @param _delta The amount of tokens less to be approved for transfer
+    /// @return Whether the approval decrease was successful or not
+    function decreaseApproval(address _spender, uint256 _delta) public returns (bool success);
+
     /// @param _owner The address of the account owning tokens
     /// @param _spender The address of the account able to transfer the tokens
     /// @return Amount of remaining tokens allowed to spent
     function allowance(address _owner, address _spender) public view returns (uint256 remaining);
+
+    /// @param _owner The address from which the balance will be retrieved
+    /// @return The balance
+    function balanceOf(address _owner) public view returns (uint256 balance);
 }


### PR DESCRIPTION
Closes #44

Last finishes:
- Add remaining HMToken methods to HMTokenInterface
- Re-order functions with style guide: https://solidity.readthedocs.io/en/v0.5.9/style-guide.html
- Edit all `uint` to explicit `uint256` for coherence and style (no practical difference)